### PR TITLE
expand PHP and Moodle versions lists for GHA

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -30,9 +30,43 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
-        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'MOODLE_404_STABLE']
-        database: [pgsql, mariadb]
+        include:
+          - php: '7.4'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: pgsql
+          - php: '8.0'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: pgsql
+          - php: '8.1'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: pgsql
+          - php: '8.0'
+            moodle-branch: 'MOODLE_402_STABLE'
+            database: pgsql
+          - php: '8.1'
+            moodle-branch: 'MOODLE_402_STABLE'
+            database: pgsql
+          - php: '8.2'
+            moodle-branch: 'MOODLE_402_STABLE'
+            database: pgsql
+          - php: '8.0'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: pgsql
+          - php: '8.1'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: pgsql
+          - php: '8.2'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: pgsql
+          - php: '8.1'
+            moodle-branch: 'MOODLE_404_STABLE'
+            database: pgsql
+          - php: '8.2'
+            moodle-branch: 'MOODLE_404_STABLE'
+            database: pgsql
+          - php: '8.3'
+            moodle-branch: 'MOODLE_404_STABLE'
+            database: pgsql
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3']
         moodle-branch: ['MOODLE_401_STABLE']
         database: [pgsql, mariadb]
 

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -16,17 +16,6 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
 
-      mariadb:
-        image: mariadb:10
-        env:
-          MYSQL_USER: 'root'
-          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
-          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
-          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
-
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.4', '8.0', '8.1', '8.2', '8.3']
-        moodle-branch: ['MOODLE_401_STABLE']
+        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'MOODLE_404_STABLE']
         database: [pgsql, mariadb]
 
     steps:


### PR DESCRIPTION
I have expanded the list of Moodle branches to check for from Moodle 4.1 up to Moodle 4.4.
Additionally, each branch is checked with the PHP versions it is compatible with, according to each release note (https://moodledev.io/general/releases)